### PR TITLE
RFC: is_valid_<string_stype> -> isvalid

### DIFF
--- a/src/mtl.jl
+++ b/src/mtl.jl
@@ -83,7 +83,7 @@ function readMtlFile(io::IO; colortype=Float64)
     while !eof(io)
         # read a line, remove newline and leading/trailing whitespaces
         line = strip(chomp(readline(io)))
-        @assert is_valid_ascii(line)
+        @assert isvalid(line)
 
         if !startswith(line, "#") && !isempty(line) && !iscntrl(line) #ignore comments
             line_parts = split(line)

--- a/src/obj.jl
+++ b/src/obj.jl
@@ -41,7 +41,7 @@ function readobj{MT <: Mesh}(io::IO, MeshType::Type{MT}=GLNormalMesh)
     for line in eachline(io)
         # read a line, remove newline and leading/trailing whitespaces
         line = strip(chomp(line))
-        @assert is_valid_ascii(line) "non valid ascii in obj"
+        @assert isvalid(line) "non valid ascii in obj"
 
         if !startswith(line, "#") && !isempty(line) && !iscntrl(line) #ignore comments
             lines        = split(line)


### PR DESCRIPTION
From what I can tell this package is targeting 0.4. This is RFC because there is no `@compat` for the deprecation yet.
